### PR TITLE
Add post id to templates

### DIFF
--- a/templates/post_reply_review_post.php
+++ b/templates/post_reply_review_post.php
@@ -1,6 +1,6 @@
 <tr bgcolor="<?= $thisbg ?>" class="tablerow">
 <td rowspan="2" valign="top" width="19%"><font class="mediumtxt"><strong><?= $post['author'] ?></strong></font><br /><br /></td>
-<td><?= $post['icon'] ?>&nbsp;<?= $poston ?></td>
+<td><?= $post['icon'] ?>&nbsp;<?= $poston ?> (#<?= $pid ?>)</td>
 </tr>
 <tr bgcolor="<?= $thisbg ?>" class="tablerow">
 <td><?= $post['message'] ?><br /></td>

--- a/templates/viewthread_post.php
+++ b/templates/viewthread_post.php
@@ -30,7 +30,7 @@
 <td valign="top" class="tablerow" style="height: 30px; width: 82%;">
 <table border="0" cellspacing="0" cellpadding="0" width="100%">
 <tr>
-<td class="smalltxt" valign="top"><?= $icon ?> <a href="<?= $full_url ?>viewthread.php?tid=<?= $tid ?>&amp;goto=search&amp;pid=<?= $pid ?>" title="<?= $linktitle ?>" rel="nofollow"><?= $poston ?></a></td>
+<td class="smalltxt" valign="top"><?= $icon ?> <a href="<?= $full_url ?>viewthread.php?tid=<?= $tid ?>&amp;goto=search&amp;pid=<?= $pid ?>" title="<?= $linktitle ?>" rel="nofollow"><?= $poston ?> (#<?= $pid ?>)</a></td>
 <td class="smalltxt" align="right" valign="top"><?= $edit ?><?= $repquote ?><?= $reportlink ?></td>
 </tr>
 </table>


### PR DESCRIPTION
Makes cross-referencing much easier when typing posts and using the 'pid' BBCode tag, as mentioned on the bug tracker. In other words, a simple QoL fix.