### PR TITLE
actually check the mysqli extension is loaded before running teh installer

### DIFF
--- a/images/install/install.css
+++ b/images/install/install.css
@@ -2,6 +2,7 @@ body {
 	font-family: arial, sans-serif;
 	font-size: 12px;
 	margin-top: 8px;
+	background:white;
 }
 
 .top {

--- a/install/web-header.php
+++ b/install/web-header.php
@@ -44,6 +44,11 @@ if (! is_readable(constant('XMB\ROOT') . 'include/version.php') || ! is_readable
     exit("Could not find the installer files!\n<br />\nPlease make sure the entire <code>include</code> and <code>install</code> folder contents are available.");
 }
 
+// Check mysqli is enabled
+if (! extension_loaded('mysqli')) {
+    exit('The MySQLi function is not loaded. Please install/enable the extension and restart your web server to start the XMB installation process. If you are unsure what this means, contact your hosting provider for support.');
+}
+
 // PHP Version Test
 require constant('XMB\ROOT') . 'include/version.php';
 $version = new XMBVersion();


### PR DESCRIPTION
Apparently if you change the background colour setting in your browser it makes all the gradient borders look weird.
![image](https://github.com/user-attachments/assets/966fa3bb-66d8-4016-989e-e1af557eeecb)

I wouldn't even have noticed this if the setting was different by default in openSUSE's build of Firefox.

This, the tiniest pull request in the world, fixes this.